### PR TITLE
Remove argument from oor_config_uci.h to make consistent

### DIFF
--- a/oor/config/oor_config_uci.h
+++ b/oor/config/oor_config_uci.h
@@ -20,6 +20,6 @@
 #ifndef OOR_CONFIG_UCI_H_
 #define OOR_CONFIG_UCI_H_
 
-int handle_config_file(char **uci_conf_file_path);
+int handle_config_file();
 
 #endif /* OOR_CONFIG_UCI_H_ */


### PR DESCRIPTION
This makes the header consistent with .c file modified at 9282da4c1f963fe81532305551b4a61438973470