### PR TITLE
Prevents openwrt init.d script, to kill itself

### DIFF
--- a/openWRT/openwrt.init.script
+++ b/openWRT/openwrt.init.script
@@ -6,7 +6,8 @@ STOP=80
 
 start() {
         echo "Stopping previous oor process ..."
-        killall oor &> /dev/null
+        killall /usr/sbin/oor &> /dev/null
+        rm /var/run/oor.pid
         echo "Starting Open Overlay Router ..."
         /usr/sbin/oor -D
 }


### PR DESCRIPTION
killall kills all, including the script.
Deletes the pid file.