### PR TITLE
Convert old style OpenWRT init script to "procd style"

### DIFF
--- a/openWRT/openwrt.init.script
+++ b/openWRT/openwrt.init.script
@@ -1,17 +1,14 @@
 #!/bin/sh /etc/rc.common
 
-START=30
+START=70
 STOP=80
+USE_PROCD=1
 
-
-start() {
-        echo "Stopping previous oor process ..."
-        killall oor &> /dev/null
-        echo "Starting Open Overlay Router ..."
-        /usr/sbin/oor -D
-}
-
-stop() {
-        echo "Stopping Open Overlay Router ..."
-        killall oor
+start_service() {
+	procd_open_instance
+	procd_set_param command /usr/sbin/oor
+	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-20}
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_close_instance
 }


### PR DESCRIPTION
Modern OpenWRT/LEDE uses procd (https://git.lede-project.org/?p=project/procd.git;a=summary)
for process management, and in order to take full advantage of its features (e.g.
automatically respawn crashed instances of a service), init scripts need to use the new
procd hooks (start_service, stop_service, ...) instead of the legacy pre-procd hooks
(start, stop, restart, ...).